### PR TITLE
Add Atlas Cloud LLM preset

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -83,6 +83,7 @@
         "modelName": "Model Name",
         "apiUrl": "API URL",
         "apiKey": "API Key",
+        "usePreset": "Use {{provider}}",
         "compatibleNote": "Compatible with any OpenAI-compatible API"
       },
       "errors": {

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -83,6 +83,7 @@
         "modelName": "模型名称",
         "apiUrl": "API 地址",
         "apiKey": "API Key",
+        "usePreset": "使用 {{provider}}",
         "compatibleNote": "兼容任意 OpenAI 标准接口"
       },
       "errors": {

--- a/src/lib/llm-presets.ts
+++ b/src/lib/llm-presets.ts
@@ -1,0 +1,30 @@
+export interface LLMConfig {
+  modelName: string
+  apiUrl: string
+  apiKey: string
+}
+
+export interface LLMProviderPreset {
+  id: string
+  label: string
+  modelName: string
+  apiUrl: string
+}
+
+export const LLM_PROVIDER_PRESETS = [
+  {
+    id: 'atlascloud',
+    label: 'Atlas Cloud',
+    modelName: 'qwen/qwen3.5-flash',
+    apiUrl: 'https://api.atlascloud.ai/v1',
+  },
+] as const satisfies readonly LLMProviderPreset[]
+
+export const applyLLMProviderPreset = (
+  config: LLMConfig,
+  preset: Pick<LLMProviderPreset, 'modelName' | 'apiUrl'>,
+): LLMConfig => ({
+  ...config,
+  modelName: preset.modelName,
+  apiUrl: preset.apiUrl,
+})

--- a/src/views/Home/components/TextGenerate.vue
+++ b/src/views/Home/components/TextGenerate.vue
@@ -44,6 +44,19 @@
               :title="t('features.llm.config.configTitle')"
             >
               <v-card-text>
+                <div class="mb-3 flex flex-wrap gap-2">
+                  <v-btn
+                    v-for="preset in LLM_PROVIDER_PRESETS"
+                    :key="preset.id"
+                    size="small"
+                    variant="tonal"
+                    color="primary"
+                    prepend-icon="mdi-cloud-outline"
+                    @click="handleApplyProviderPreset(preset)"
+                  >
+                    {{ t('features.llm.config.usePreset', { provider: preset.label }) }}
+                  </v-btn>
+                </div>
                 <v-text-field
                   :label="t('features.llm.config.modelName')"
                   v-model="config.modelName"
@@ -116,6 +129,11 @@ import { useToast } from 'vue-toastification'
 import { useTranslation } from 'i18next-vue'
 import ActionToastEmbed from '@/components/ActionToastEmbed.vue'
 import { formatErrorForCopy } from '@/lib/error-copy'
+import {
+  LLM_PROVIDER_PRESETS,
+  applyLLMProviderPreset,
+  type LLMProviderPreset,
+} from '@/lib/llm-presets'
 
 const toast = useToast()
 const appStore = useAppStore()
@@ -202,6 +220,9 @@ const config = ref(structuredClone(toRaw(appStore.llmConfig)))
 const configDialogShow = ref(false)
 const resetConfigDialog = () => {
   config.value = structuredClone(toRaw(appStore.llmConfig))
+}
+const handleApplyProviderPreset = (preset: LLMProviderPreset) => {
+  config.value = applyLLMProviderPreset(config.value, preset)
 }
 const handleCloseDialog = () => {
   configDialogShow.value = false


### PR DESCRIPTION
## Summary
- add an Atlas Cloud preset for the existing OpenAI-compatible LLM configuration dialog
- prefill the Atlas Cloud base URL and live-verified default model (`qwen/qwen3.5-flash`)
- keep the user's existing API key untouched when applying the preset

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec prettier --check src/lib/llm-presets.ts src/views/Home/components/TextGenerate.vue locales/en/common.json locales/zh-CN/common.json`
- `pnpm exec vue-tsc --noEmit`
- `VITE_CJS_IGNORE_WARNING=true pnpm exec vite build`
- `jq empty locales/en/common.json && jq empty locales/zh-CN/common.json`
- `git diff --check`
- Atlas Cloud live model catalog confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No README or promotional sections were changed.
